### PR TITLE
Files can be edited inside of diagnostics/documentation floating windows

### DIFF
--- a/lua/raizento/init.lua
+++ b/lua/raizento/init.lua
@@ -1,3 +1,5 @@
+require("raizento.util.patches")
+
 require("raizento.launch")
 require("raizento.core.options")
 require("raizento.core.keymap")

--- a/lua/raizento/lsp/diagnostic.lua
+++ b/lua/raizento/lsp/diagnostic.lua
@@ -1,13 +1,3 @@
-local original_open_floating_window = vim.lsp.util.open_floating_preview
-
--- Patch internal function to set winfixbuf option
--- Prevents switching the buffer inside of the "informational" LSP/diagnostic floating windows
-vim.lsp.util.open_floating_preview = function(contents, format, config)
-  local bufnr, winid = original_open_floating_window(contents, format, config)
-  vim.wo[winid].winfixbuf = true
-  return bufnr, winid
-end
-
 function add_diagnostic_keymaps(bufnr)
   vim.keymap.set("n", "<Leader>de", vim.diagnostic.open_float, { buffer = bufnr }, "open float")
   vim.keymap.set("n", "<Leader>dl", function()

--- a/lua/raizento/util/patches.lua
+++ b/lua/raizento/util/patches.lua
@@ -1,0 +1,12 @@
+-- File which contains patches to vim functions
+-- Should be loaded first
+
+local original_open_floating_window = vim.lsp.util.open_floating_preview
+
+-- Patch internal function to set winfixbuf option
+-- Prevents switching the buffer inside of the "informational" LSP/diagnostic floating windows
+vim.lsp.util.open_floating_preview = function(contents, format, config)
+  local bufnr, winid = original_open_floating_window(contents, format, config)
+  vim.wo[winid].winfixbuf = true
+  return bufnr, winid
+end


### PR DESCRIPTION
# Closes #18 

# Implementation details
- Patched `vim.lsp.util.open_floating_preview` to set the `winfixbuf` option so that the buffer inside of the floating windows cannot be swapped out