### PR TITLE
Automatically start up LSP once installed with Mason

### DIFF
--- a/lua/raizento/lsp/init.lua
+++ b/lua/raizento/lsp/init.lua
@@ -34,13 +34,32 @@ vim.api.nvim_create_autocmd("LspAttach", {
   end,
 })
 
-local lsp_names = lsp.get_mason_lsp_names()
+local function enable_lsps_installed_with_mason()
+  local lsp_names = lsp.get_mason_lsp_names()
 
-for _, lsp_name in ipairs(lsp_names) do
-  vim.lsp.config(lsp_name, {
-    -- Capabilities automatically get merged
-    capabilities = require("cmp_nvim_lsp").default_capabilities(),
-  })
+  for _, lsp_name in ipairs(lsp_names) do
+    vim.lsp.config(lsp_name, {
+      -- Capabilities automatically get merged
+      capabilities = require("cmp_nvim_lsp").default_capabilities(),
+    })
 
-  vim.lsp.enable(lsp_name)
+    vim.lsp.enable(lsp_name)
+  end
 end
+
+-- This is a very hacky solution to https://github.com/Raizento/nvim-config/issues/23;
+-- won't work if nvim is used headless
+-- Open issue in Mason: https://github.com/mason-org/mason.nvim/issues/2074
+vim.api.nvim_create_autocmd("BufLeave", {
+  callback = function(_)
+    local ft = vim.o.filetype
+
+    if ft ~= "mason" then
+      return
+    end
+
+    enable_lsps_installed_with_mason()
+  end
+})
+
+enable_lsps_installed_with_mason()

--- a/lua/raizento/lsp/init.lua
+++ b/lua/raizento/lsp/init.lua
@@ -60,7 +60,7 @@ vim.api.nvim_create_autocmd("BufLeave", {
     end
 
     enable_lsps_installed_with_mason()
-  end
+  end,
 })
 
 enable_lsps_installed_with_mason()

--- a/lua/raizento/lsp/init.lua
+++ b/lua/raizento/lsp/init.lua
@@ -50,6 +50,7 @@ end
 -- This is a very hacky solution to https://github.com/Raizento/nvim-config/issues/23;
 -- won't work if nvim is used headless
 -- Open issue in Mason: https://github.com/mason-org/mason.nvim/issues/2074
+-- For this to work it also needs the Mason window to stay open until the LSP was installed successfully. If it's closed beforehand the LSP won't be enabled
 vim.api.nvim_create_autocmd("BufLeave", {
   callback = function(_)
     local ft = vim.o.filetype


### PR DESCRIPTION
Added a `BufLeave` autocommand that will now enable all LSPs again if a buffer with filetype `mason` is about to be left. 
This won't work if the Mason window opened by `Mason`/`MasonInstall` is closed before installation is done. 

Also see Mason issue https://github.com/mason-org/mason.nvim/issues/2074